### PR TITLE
Fixed EArgumentOutOfRangeException

### DIFF
--- a/FMX.RichEdit.Style.pas
+++ b/FMX.RichEdit.Style.pas
@@ -121,7 +121,8 @@ procedure TRichEditLinesLayout.ReplaceLine(const AIndex: Integer; const ALine: s
 begin
   inherited;
   // We have to reapply style attributes after line modification
-  Items[AIndex].InvalidateLayout;
+  if (AIndex >= 0) and (AIndex < Count) then // Guard against invalid indices (e.g. when lines are cleared)
+    Items[AIndex].InvalidateLayout;
 end;
 
 procedure TRichEditLinesLayout.SetCodeSyntaxName(const Lang: string; const DefFont: TFont; DefColor: TAlphaColor);
@@ -275,8 +276,14 @@ end;
 procedure TRichEditStyled.UpdateVisibleLayoutParams;
 begin
   TRichEditLinesLayout(Editor.LinesLayout).ClearCache;
+  var First := Editor.LinesLayout.FirstVisibleLineIndex;
+  var Last := Editor.LinesLayout.LastVisibleLineIndex;
+  if (First < 0) or (Last < 0) or (First > Last) then
+    Exit;
+  if Last >= Editor.LinesLayout.Count then
+    Last := Editor.LinesLayout.Count - 1;
 
-  for var i := Editor.LinesLayout.FirstVisibleLineIndex to Editor.LinesLayout.LastVisibleLineIndex do
+  for var i := First to Last do
   begin
     var Line := Editor.LinesLayout.Items[i];
     if Line.Layout <> nil then


### PR DESCRIPTION
Happens sometimes when you try to `Memo.Lines.Clear();` or `Memo.Text := '';`.